### PR TITLE
add options: cssFiles, scriptFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ Default settings are as follows:
 port: 6275
 dest: build
 source: slides.md
-assets: ['assets']
 title: ''
+assets: ['assets']
 css: ''
+cssFiles: []
+script: ''
+scriptFiles: []
 remarkConfig: {}
 remarkPath: moduleDir + '/vendor/remark.js'
 ```
@@ -98,11 +101,13 @@ remarkPath: moduleDir + '/vendor/remark.js'
 - `source` is the source markdown filename. Default is `slides.md`.
 - `title` is the page title of the slides. Default is an empty string.
 - `css` is css text you want to add to slides' html page.
+- `cssFiles` is the list of additional stylesheet files (URL or the file path relative to your current working director) you want to add to slides' html page. If you provide file paths, these files are copied/served statically. Default is an empty array.
 
 ## Advanced options
 
 - `assets` is the list of assets directory. These directories are copied/served statically.
-- `script` is additional JavaScript appended after the remark.js. Default is an empty string.
+- `scriptFiles` is the list of additional JavaScript files (URL or the file path relative to your current working director) appended after the remark.js. If you provide file paths, these files are copied/served statically. Default is an empty array.
+- `script` is additional JavaScript code appended after the remark.js and `scriptFiles`. Default is an empty string.
 - `remarkConfig` is the config object which is passed to remark.create(options). Default is an empty object.
   - See [the remark source code](https://github.com/gnab/remark/blob/develop/src/remark/models/slideshow.js#L41-L48) for what option is available.
 - `remarkPath` is the path to remark.js. This replaces the original remark.js with specified one.

--- a/index.js
+++ b/index.js
@@ -34,7 +34,9 @@ const defaultConfig = {
   dest: 'build',
   source: 'slides.md',
   css: defaultCss,
+  cssFiles: [],
   script: '',
+  scriptFiles: [],
   remarkConfig: {},
   remarkPath: join(__dirname, 'vendor', 'remark.js'),
   assets: ['assets']
@@ -53,7 +55,9 @@ on('config', config => {
     .pipe(layout1.nunjucks(layoutFilename, {
       data: {
         css: config.css,
+        cssFiles: config.cssFiles.map(url => `<link href="${url}" rel="stylesheet" />`).join('\n'),
         script: config.script,
+        scriptFiles: config.scriptFiles.map(url => `<script src="${url}"></script>`).join('\n'),
         title: config.title,
         remarkConfig: config.remarkConfig
       }
@@ -61,6 +65,21 @@ on('config', config => {
 
   asset(config.remarkPath)
     .pipe(rename('remark.js'))
+
+  config.cssFiles.forEach(src => {
+    if (/^http/.test(src)) {
+      return
+    }
+    asset(src).base(process.cwd())
+  })
+
+  config.scriptFiles.forEach(src => {
+    if (/^http/.test(src)) {
+      return
+    }
+    asset(src).base(process.cwd())
+  })
+
 
   config.assets.forEach(src => {
     asset(join(src, '**/*.*')).base(process.cwd())

--- a/layout.njk
+++ b/layout.njk
@@ -3,6 +3,7 @@
   <head>
     <title>{{ title }}</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    {{ cssFiles | safe }}
     <style type="text/css">
       {{ css | safe }}
     </style>
@@ -10,6 +11,7 @@
   <body>
     <textarea id="source">{{ file.contents | safe }}</textarea>
     <script src="remark.js"></script>
+    {{ scriptFiles | safe }}
     <script>
       remark.create({{ remarkConfig | dump | safe }})
     </script>


### PR DESCRIPTION
For example:

```yml
# remarker.yml
dest: build
cssFiles:
  - 'styles/index.css'
scriptFiles:
  - 'node_modules/mermaid/dist/mermaid.min.js'
```

Output:

```
build
├── index.html
├── node_modules
│   └── mermaid
│       └── dist
│           └── mermaid.min.js
├── remark.js
└── styles
    └── index.css
```

```html
<!-- build/index.html -->
<!DOCTYPE html>
<html>
  <head>
    <title>....</title>
    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
    <link href="styles/index.css" rel="stylesheet" />
    <style type="text/css">
    <!-- ... -->
    <script src="remark.js"></script>
    <script src="node_modules/mermaid/dist/mermaid.min.js"></script>
    <script>
```