### PR TITLE
Script files can load after remark.create() now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ script: ''
 scriptFiles: []
 remarkConfig: {}
 remarkPath: moduleDir + '/vendor/remark.js'
+scriptFilesAfterCreate: []
 livereload: true
 livereloadPort: 35729
 ```
@@ -117,6 +118,7 @@ livereloadPort: 35729
 - `remarkConfig` is the config object which is passed to remark.create(options). Default is an empty object.
   - See [the remark source code](https://github.com/gnab/remark/blob/develop/src/remark/models/slideshow.js#L41-L48) for what option is available.
 - `remarkPath` is the path to remark.js. This replaces the original remark.js with specified one.
+- `scriptFilesAfterCreate`  is the list of additional JavaScript files (URL or the file path relative to your current working director) appended after the `remark.create()`. If you provide file paths, these files are copied/served statically. Default is an empty array.
 - `livereload` is the flag to toggle livereloading feature. Default is true.
 - `livereloadPort` is the port number for livereloading websocket connection. Default is 35729.
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,8 @@ const defaultConfig = {
   scriptFiles: [], // The additional script files
   remarkConfig: {}, // The config object passed to remark
   remarkPath: join(__dirname, 'vendor', 'remark.js'), // The remark path
-  assets: [defaultAssetsPath], // The asset paths,
+  scriptFilesAfterCreate: [], // The additional script files loaded after remark.create
+  assets: [defaultAssetsPath], // The asset paths
   'open-browser': false // open the browser to the page when the server starts
 }
 

--- a/layout.njk
+++ b/layout.njk
@@ -19,6 +19,9 @@
     <script>
       window.slideshow = remark.create({{ remarkConfig | dump | safe }})
     </script>
+    {% for file in scriptFilesAfterCreate %}
+    <script src="{{ file }}"></script>
+    {% endfor %}
     <script>
       {{ script | safe }}
       ;window.LiveReloadOptions = {


### PR DESCRIPTION
Add scriptFilesAfterCreate item to YAML config file:

scriptFilesAfterCreate: []

Script filess in this list will loaded after remark.create()